### PR TITLE
add tests to cover adding files with keys including /.

### DIFF
--- a/tests/read-write.js
+++ b/tests/read-write.js
@@ -18,6 +18,23 @@ module.exports.blobWriteStream = function(test, common) {
   })
 }
 
+module.exports.blobWriteStreamSubFolder = function(test, common) {
+  test('piping a blob into a blob write stream in nonexisting subfolder', function(t) {
+    common.setup(test, function(err, store) {
+      t.notOk(err, 'no setup err')
+      var ws = store.createWriteStream({name: 'folder/test.js'}, function(err, obj) {
+        t.error(err)
+        t.ok(obj.key, 'blob has key')
+        common.teardown(test, store, obj, function(err) {
+          t.error(err)
+          t.end()
+        })
+      })
+      from([new Buffer('foo'), new Buffer('bar')]).pipe(ws)
+    })
+  })
+}
+
 module.exports.blobReadStream = function(test, common) {
   test('reading a blob as a stream', function(t) {
     common.setup(test, function(err, store) {
@@ -100,6 +117,7 @@ module.exports.blobExists = function(test, common) {
 
 module.exports.all = function (test, common) {
   module.exports.blobWriteStream(test, common)
+  module.exports.blobWriteStreamSubFolder(test, common)
   module.exports.blobReadStream(test, common)
   module.exports.blobReadError(test, common)
   module.exports.blobExists(test, common)

--- a/tests/string-key.js
+++ b/tests/string-key.js
@@ -18,6 +18,23 @@ module.exports.blobWriteStream = function(test, common) {
   })
 }
 
+module.exports.blobWriteStreamSubFolder = function(test, common) {
+  test('piping a blob into a blob write stream with string key in nonexisting subfolder', function(t) {
+    common.setup(test, function(err, store) {
+      t.notOk(err, 'no setup err')
+      var ws = store.createWriteStream('folder/hello-world.txt', function(err, obj) {
+        t.error(err)
+        t.ok(obj.key, 'blob has key')
+        common.teardown(test, store, obj, function(err) {
+          t.error(err)
+          t.end()
+        })
+      })
+      from([new Buffer('foo'), new Buffer('bar')]).pipe(ws)
+    })
+  })
+}
+
 module.exports.blobReadStream = function(test, common) {
   test('reading a blob as a stream with string key', function(t) {
     common.setup(test, function(err, store) {
@@ -99,6 +116,7 @@ module.exports.blobExists = function(test, common) {
 
 module.exports.all = function (test, common) {
   module.exports.blobWriteStream(test, common)
+  module.exports.blobWriteStreamSubFolder(test, common)
   module.exports.blobReadStream(test, common)
   module.exports.blobReadError(test, common)
   module.exports.blobExists(test, common)


### PR DESCRIPTION
Some implementations of abstract-blob-store use the provided key as the key in the blob store. If the key is interpreted as a path and stored in subfolders no tests cover this scenario. These 2 tests create a blob in a subfolder that does not exist, and this needs to be handled by the implementation. I´m a bit uncertain about this as you advice to store the blob in a content-addressed storage, I guess these tests does not make that much sense then?