### PR TITLE
Change npm license property to "BSD-2-Clause"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "node tests/run.js"
   },
   "author": "max ogden",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "dependencies": {
     "concat-stream": "^1.4.6",
     "from2-array": "0.0.3"


### PR DESCRIPTION
This tiny PR changes the npm `license` property from `BSD` to `BSD-2-Clause`, to match the content of `LICENSE`.

`BSD-2-Clause` is a valid SPDX-standard identifier, and will helps folks check automatically that the terms for abstract-blob-store aren't any problem.

Thanks!

K
