### PR TITLE
Revert "Remove breaking change from 3.0.0 range"

### DIFF
--- a/tests/read-write.js
+++ b/tests/read-write.js
@@ -57,7 +57,7 @@ module.exports.blobReadError = function(test, common) {
 
       rs.on('error', function(e) {
         t.ok(e, 'got a read stream err')
-        // t.ok(e.notFound, 'error reports not found')
+        t.ok(e.notFound, 'error reports not found')
         common.teardown(test, store, undefined, function(err) {
           t.error(err)
           t.end()


### PR DESCRIPTION
This reverts commit 2f4e14d49f807afc7661d314c2e8b3210fac8b5d.

While it was discovered a change made in the 3.x range was breaking downstream implementations, the error property was in play for a year or so, and some people implemented it.  

To land this, we need to add the error property to the specification description, and ensure it can be implemented in various contents.  I propose https://github.com/mafintosh/content-addressable-blob-store as a good candidate to implement the pattern.

- [ ] Document property in spec
- [ ] Implement in CABS

I don't have time to do this imediately so help wanted if people want to land this sooner.  
cc @kemitchell 